### PR TITLE
Install pychef with package name as non-editable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+http://github.com/coderanger/pychef.git#egg=Package
+git+http://github.com/coderanger/pychef.git#egg=PyChef
 prettytable==0.7.2


### PR DESCRIPTION
This change makes the installation non-editable (_i.e._ not `setup.py develop`, just `setup.py`). It also installs the package with the proper #egg designation of #egg=PyChef.
